### PR TITLE
Update BotApi.php (PHP 8.4 nullable deprecation)

### DIFF
--- a/src/BotApi.php
+++ b/src/BotApi.php
@@ -244,7 +244,7 @@ class BotApi
      * @throws HttpException
      * @throws InvalidJsonException
      */
-    public function call($method, array $data = null, $timeout = null)
+    public function call($method, ?array $data = null, ?int $timeout = null)
     {
         if ($timeout !== null) {
             @trigger_error(sprintf('Passing $timeout parameter in %s::%s is deprecated. Use http client options', __CLASS__, __METHOD__), \E_USER_DEPRECATED);


### PR DESCRIPTION
PHP Deprecated:  TelegramBot\Api\BotApi::call(): Implicitly marking parameter $data as nullable is deprecated, the explicit nullable type must be used instead in src/BotApi.php on line 247